### PR TITLE
Also detect all columns in FindSql

### DIFF
--- a/src/main/java/org/openrewrite/sql/SqlDetector.java
+++ b/src/main/java/org/openrewrite/sql/SqlDetector.java
@@ -26,10 +26,7 @@ import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitorAdapter;
 import net.sf.jsqlparser.statement.delete.Delete;
-import net.sf.jsqlparser.statement.select.PlainSelect;
-import net.sf.jsqlparser.statement.select.Select;
-import net.sf.jsqlparser.statement.select.SelectItem;
-import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
+import net.sf.jsqlparser.statement.select.*;
 import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.statement.update.UpdateSet;
 import org.jspecify.annotations.Nullable;
@@ -170,16 +167,24 @@ public class SqlDetector {
         String table;
 
         @Override
+        public void visit(AllColumns columns) {
+            addRowForColumnName(columns.toString());
+        }
+
+        @Override
         public void visit(Column column) {
-            DatabaseColumnsUsed.Row row = new DatabaseColumnsUsed.Row(
+            addRowForColumnName(column.getColumnName());
+        }
+
+        private void addRowForColumnName(String columnName) {
+            addRow(rows, new DatabaseColumnsUsed.Row(
                     separatorsToUnix(sourceFile.getSourcePath().toString()),
                     lineNumber,
                     commitHash,
                     operation,
                     table,
-                    column.getColumnName()
-            );
-            addRow(rows, row);
+                    columnName
+            ));
         }
     }
 

--- a/src/test/java/org/openrewrite/sql/FindSqlTest.java
+++ b/src/test/java/org/openrewrite/sql/FindSqlTest.java
@@ -194,4 +194,34 @@ class FindSqlTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void allColumns() {
+        rewriteRun(
+          spec -> spec.dataTable(DatabaseColumnsUsed.Row.class, rows -> {
+              assertThat(rows).hasSize(1);
+              DatabaseColumnsUsed.Row row = rows.get(0);
+              assertThat(row.getOperation()).isEqualTo(DatabaseColumnsUsed.Operation.SELECT);
+              assertThat(row.getTable()).isEqualTo("table");
+              assertThat(row.getColumn()).isEqualTo("*");
+          }),
+          //language=java
+          java(
+            """
+              class Test {
+                  void test() {
+                      String sql = "select * from table where id = 1";
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      String sql = /*~~>*/"select * from table where id = 1";
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/sql/FindSqlTest.java
+++ b/src/test/java/org/openrewrite/sql/FindSqlTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.sql;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.Tree;
 import org.openrewrite.marker.GitProvenance;
 import org.openrewrite.sql.table.DatabaseColumnsUsed;
@@ -195,6 +196,7 @@ class FindSqlTest implements RewriteTest {
         );
     }
 
+    @DocumentExample
     @Test
     void allColumns() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/sql/trait/SqlQueryTest.java
+++ b/src/test/java/org/openrewrite/sql/trait/SqlQueryTest.java
@@ -38,7 +38,6 @@ class SqlQueryTest implements RewriteTest {
           .expectedCyclesThatMakeChanges(1);
     }
 
-    @DocumentExample
     @Test
     void probablyButNotActuallySql() {
         rewriteRun(
@@ -53,6 +52,7 @@ class SqlQueryTest implements RewriteTest {
         );
     }
 
+    @DocumentExample
     @Test
     void javaLiteral() {
         rewriteRun(


### PR DESCRIPTION
Previously we only detected specifically named columns, but that meant an SQL statement like this one was missed:
```sql
select * from table where id = 1
```